### PR TITLE
Update CI to use PyPi API token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,8 +114,7 @@ jobs:
           token: ${{ secrets.VAULT_TOKEN }}
           secrets: |
             kv/data/github  "SSH_PRIVATE_KEY"     | SSH_PRIVATE_KEY;
-            kv/data/pypi    "PASSWORD"            | POETRY_HTTP_BASIC_PYPI_USERNAME;
-            kv/data/pypi    "USERNAME"            | POETRY_HTTP_BASIC_PYPI_PASSWORD;
+            kv/data/pypi    "API_TOKEN"           | POETRY_HTTP_BASIC_PYPI_API_TOKEN;
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -161,8 +160,10 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
-
       - name: Build and push the python package
+        env:
+          # When using a PYPI API token, the user name must be set to "__token__"
+          POETRY_HTTP_BASIC_PYPI_USERNAME: __token__
         run: go run mage.go release
 
       - name: Bump to the next version


### PR DESCRIPTION
Pypi no longer allows publishing packages using username/password.